### PR TITLE
Update service.yaml

### DIFF
--- a/helm-lab/templates/service.yaml
+++ b/helm-lab/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "helmHook.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "helmHook.name" . }}
+    app.kubernetes.io/name: {{ include "helmHook.name" . | lower}}
     helm.sh/chart: {{ include "helmHook.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -15,5 +15,5 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app.kubernetes.io/name: {{ include "helmHook.name" . }}
+    app.kubernetes.io/name: {{ include "helmHook.name" . | lower}}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
fixing this error when deploying this chart

Error: Service "helm-native-q9-zbpenoz-helmHook" is invalid: metadata.name: Invalid value: "helm-native-q9-zbpenoz-helmHook": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name', or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')